### PR TITLE
Update ubuntu-core url

### DIFF
--- a/chrx-install
+++ b/chrx-install
@@ -284,7 +284,7 @@ get_os_version_and_core_url_dev_ubuntu()
   release_log="`curl -s ${release_log_url}`"
   codename=`echo "${release_log}"|grep "^Dist: "|tail -1|awk '{print $2}'`
   CHRX_OS_VERSION=`echo "${release_log}"|grep "^Version: "|tail -1|awk '{print $2}'`
-  CHRX_OS_CORE_IMAGE_URL="http://cdimage.ubuntu.com/ubuntu-core/daily/current/${codename}-core-${CHRX_OS_ARCH}.tar.gz"
+  CHRX_OS_CORE_IMAGE_URL="http://cdimage.ubuntu.com/ubuntu-core/daily-preinstalled/current/${codename}-preinstalled-core-${CHRX_OS_ARCH}.tar.gz"
 }
 
 get_os_version_ubuntu()
@@ -312,7 +312,7 @@ determine_osv_ubuntu()
   esac
 
   if [ -z "${CHRX_OS_CORE_IMAGE_URL}" ]; then
-    CHRX_OS_CORE_IMAGE_URL="http://cdimage.ubuntu.com/ubuntu-core/releases/${CHRX_OS_VERSION}/release/ubuntu-core-${CHRX_OS_VERSION}-core-${CHRX_OS_ARCH}.tar.gz"
+    CHRX_OS_CORE_IMAGE_URL="http://cdimage.ubuntu.com/ubuntu-core/${CHRX_OS_RELEASE}/daily-preinstalled/current/${CHRX_OS_RELEASE}-preinstalled-core-${CHRX_OS_ARCH}.tar.gz"
   fi
 
   case "${CHRX_OS_VERSION}" in


### PR DESCRIPTION
It seems Ubuntu has updated their URL structure and no longer has the releases subfolder. I was able to successfully download a new core image from the urls in the patch below.

I did hit an issue where using 16.04 as `-r` parameter is no longer valid, since now we do require the Ubuntu codename. Probably the switch statement above can be changed to do the reverse, but I didn't looked into it.