### PR TITLE
Change Fedora latest to auto-detection (for fedora 25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ Options
 **chrx** can install additional software packages after installing
 your new operating system, using the `-p PACKAGE` option.
 
-This option is not yet supported on Fedora!
-
 You can install any package in the Ubuntu repositories via this
 method, plus a few non-Ubuntu packages for which **chrx** has
 special handling, and some aliases for convenience:

--- a/chrx-install
+++ b/chrx-install
@@ -425,27 +425,43 @@ determine_osv_galliumos()
   esac
 }
 
+get_os_version_fedora()
+{
+  release_log_url="http://dl.fedoraproject.org/pub/fedora/linux/releases/"
+  version_list=$(curl -s ${release_log_url} | grep -Eo ">[0-9][0-9]/" | grep -o "[0-9][0-9]")
+  CHRX_OS_VERSION=$(echo "${version_list}" | sort | tail -1)
+  # default to 25
+  if [[ $CHRX_OS_VERSION != [0-9][0-9] ]]; then
+    CHRX_OS_VERSION=25
+  fi
+}
+
 determine_osv_fedora()
 {
   msg_os_version="${ANSI_YEL}(CAUTION: chrx support is beta!)${ANSI_RST}"
   case "${CHRX_OS_RELEASE}" in
     latest)
-      CHRX_OS_VERSION=24
+      get_os_version_fedora
       ;;
-    22,23,24)
+    24,25)
       CHRX_OS_VERSION=${CHRX_OS_RELEASE}
       ;;
-    25)
-      msg_os_version="${ANSI_RED}(CAUTION: not tested!)${ANSI_RST}"
+    rawhide)
       CHRX_OS_VERSION=${CHRX_OS_RELEASE}
+      msg_os_version="${ANSI_YEL}(CAUTION: development version; may not work!)${ANSI_RST}"
       ;;
     *)
-      msg_os_version="${ANSI_RED}(invalid!)${ANSI_RST}"
-      FAIL=1
+      if [[ ${CHRX_OS_RELEASE} == [0-9][0-9] ]]; then
+        CHRX_OS_VERSION=${CHRX_OS_RELEASE}
+        msg_os_version="${ANSI_YEL}(CAUTION: untested!)${ANSI_RST}"
+      else
+        msg_os_version="${ANSI_RED}(invalid!)${ANSI_RST}"
+        FAIL=1
+      fi
       ;;
   esac
   
-  CHRX_OS_CORE_IMAGE_URL='https://download.fedoraproject.org/pub/fedora/linux/releases/24/Docker/x86_64/images/Fedora-Docker-Base-24-1.2.x86_64.tar.xz'
+  CHRX_OS_CORE_IMAGE_URL='https://download.fedoraproject.org/pub/fedora/linux/releases/25/Docker/x86_64/images/Fedora-Docker-Base-25-1.3.x86_64.tar.xz'
   
 }
 
@@ -783,15 +799,6 @@ validate_config()
     i386|amd64) ;;
     *) msg_os_arch="${ANSI_RED}invalid${ANSI_RST}" ; FAIL=1 ;;
   esac
-
-  if [ "$CHRX_ADD_PKGS" ]; then
-    case "${CHRX_OS_DISTRO}" in
-      fedora)
-        msg_os_pkgs="${ANSI_YEL}NOTE: not yet supported on ${CHRX_OS_DISTRO_DISPLAYNAME}${ANSI_RST}"
-        CHRX_ADD_PKGS=
-        ;;
-    esac
-  fi
 }
 
 confirm_config()
@@ -923,8 +930,7 @@ do_install()
   mkdir -p ${CHRX_INSTALL_ROOT}${CHRX_CACHE_DIR}
   cd ${CHRX_INSTALL_ROOT}${CHRX_CACHE_DIR}
   curl ${VERBOSITY_CURL} ${CHRX_WEB_ROOT}/dist.tar.gz | tar xz --no-same-owner
-  #cp -rf dist/* ${CHRX_INSTALL_ROOT}${CHRX_CACHE_DIR}
-
+  
   if [ "${CHRX_CUSTOMIZATION_ENABLED}" ]; then
     install_customizations
   else

--- a/dist/chrx-install-chroot
+++ b/dist/chrx-install-chroot
@@ -134,6 +134,71 @@ install_set_hdr()
   install_google_chrome_from_deb
 }
 
+fedora_install_additional_packages()
+{
+  for pkg in ${CHRX_ADD_PKGS}; do
+    echo_title "Installing additional package \"${pkg}\"."
+    case $pkg in
+      admin-misc)
+        dnf ${VERBOSITY_DNF} -y install vim tmux rsync openssh
+        ;;
+      dev-misc)
+        dnf ${VERBOSITY_DNF} -y install arduino geany geany-plugins-addons ruby ;;
+      kodi)
+        fedora_install_rpmfusion;
+        dnf ${VERBOSITY_DNF} -y install kodi
+        ;;
+      minecraft)
+        fedora_install_minecraft
+        ;;
+      steam)
+        fedora_install_rpmfusion
+        dnf ${VERBOSITY_DNF} -y install steam
+        ;;
+      simplescreenrecorder)
+        fedora_install_rpmfusion
+        dnf ${VERBOSITY_DNF} -y install simplescreenrecorder
+        ;;
+      chrome)
+        fedora_install_google_chrome
+        ;;
+      _hdr)
+        fedora_install_set_hdr
+        ;;
+      *)
+        dnf ${VERBOSITY_DNF} -y install $pkg ;;
+    esac
+  done
+}
+
+fedora_install_minecraft()
+{
+  dnf ${VERBOSITY_DNF} -y install java
+  curl -o /usr/local/bin/Minecraft.jar \
+    https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.jar
+  curl -o /usr/share/pixmaps/minecraft.png https://chrx.org/minecraft.png
+  mkdir -p /usr/local/share/applications
+  cat > /usr/local/share/applications/minecraft.desktop <<-EOF
+	[Desktop Entry]
+	Type=Application
+	Name=Minecraft
+	Comment=Minecraft
+	Exec=java -jar /usr/local/bin/Minecraft.jar
+	Icon=/usr/share/pixmaps/minecraft.png
+	Categories=Game;
+	EOF
+}
+
+fedora_install_set_hdr()
+{
+  fedora_install_rpmfusion
+  dnf ${VERBOSITY_DNF} -y install vim tmux rsync openssh
+  dnf ${VERBOSITY_DNF} -y install arduino geany geany-plugins-addons ruby
+  fedora_install_minecraft
+  dnf ${VERBOSITY_DNF} -y install steam
+  fedora_install_google_chrome
+}
+
 ubuntu_add_repos()
 {
   echo_title "Adding Ubuntu software respositories."
@@ -350,7 +415,6 @@ install_google_chrome()
 
   apt_get_update_if_needed
   echo_title "Installing Google Chrome."
-  apt_get_install google-chrome-stable
 }
 
 fedora_install_google_chrome()
@@ -361,9 +425,37 @@ fedora_install_google_chrome()
   dnf ${VERBOSITY_DNF} -y install https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
 }
 
+
+fedora_install_rpmfusion()
+{
+  echo_title "Installing RPM Fusion software repository."
+  
+  dnf ${VERBOSITY_DNF} -y install \
+    https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
+    https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+}
+
+fedora_install_codecs()
+{
+  [ ! -x /usr/bin/X ] && return ## only if we have X
+
+  fedora_install_rpmfusion
+  
+  echo_title "Installing non-free codecs codecs."
+  
+  dnf ${VERBOSITY_DNF} -y install gstreamer gstreamer-plugins-base  gstreamer-plugins-good \
+    gstreamer-plugins-good-extras gstreamer-plugins-bad gstreamer-plugins-bad-free gstreamer-plugins-bad-free-extras \
+    gstreamer-plugins-bad-nonfree gstreamer-plugins-ugly gstreamer-ffmpeg
+
+  dnf ${VERBOSITY_DNF} -y install gstreamer1 gstreamer1-plugins-base gstreamer1-plugins-base-tools gstreamer1-plugins-good gstreamer1-plugins-good-extras gstreamer1-plugins-bad-free gstreamer1-plugins-bad-free-extras gstreamer1-plugins-bad-freeworld gstreamer1-plugins-ugly gstreamer1-libav
+
+  dnf ${VERBOSITY_DNF} -y install faad2 faac libdca compat-libstdc++-33 compat-libstdc++-296 xine-lib-extras-freeworld
+}
+
 install_desktop_support()
 {
   [ ! -x /usr/bin/X ] && return ## only if we have X
+  [ ! "${CHRX_CUSTOMIZATION_ENABLED}" ] && return
 
   echo_title "Installing desktop compatibility pkgs."
   apt_get_install xbindkeys xdotool xbacklight xvkbd
@@ -593,13 +685,18 @@ case "${CHRX_OS_DISTRO}" in
   fedora)
     fedora_install_kernel
     fedora_install_distenv
-    fedora_install_desktop_support
-    fedora_install_google_chrome
     fedora_set_timezone
     fedora_set_locale
     write_default_fstab
     fedora_install_grub2
-    fedora_set_selinux_autolabel
+    if [ "${CHRX_CUSTOMIZATION_ENABLED}" ]; then
+      fedora_install_desktop_support
+      fedora_install_google_chrome
+      fedora_install_codecs
+    else
+      fedora_set_selinux_autolabel
+    fi
+    fedora_install_additional_packages
     ;;
 esac
 


### PR DESCRIPTION
Add Fedora support for -p
Add Fedora nonfree codec installation

Hi,
This should be the last update for a while:

- Auto detect the latest Fedora version (similar to Ubuntu),
- Install extra packages
- Install non-free codecs (MP3, MPEG2 etc) with the customizations enabled
- Allow for installing the development/rolling branch

This is pretty much everything I can think of to bring this branch up to parity with the Ubuntu installation.