### PR TITLE
Fixes for Fedora 30 and 31

### DIFF
--- a/chrx-install
+++ b/chrx-install
@@ -581,7 +581,7 @@ get_os_version_fedora()
   CHRX_OS_VERSION=$(echo "${version_list}" | sort | tail -1)
   # default to 25
   if [[ $CHRX_OS_VERSION != [0-9][0-9] ]]; then
-    CHRX_OS_VERSION=27
+    CHRX_OS_VERSION=30
   fi
 }
 
@@ -592,7 +592,7 @@ determine_osv_fedora()
     latest)
       get_os_version_fedora
       ;;
-    26,27)
+    28,29,30)
       CHRX_OS_VERSION=${CHRX_OS_RELEASE}
       ;;
     rawhide)
@@ -610,7 +610,7 @@ determine_osv_fedora()
       ;;
   esac
   
-  CHRX_OS_CORE_IMAGE_URL='https://download.fedoraproject.org/pub/fedora/linux/releases/27/Docker/x86_64/images/Fedora-Docker-Base-27-1.6.x86_64.tar.xz'
+  CHRX_OS_CORE_IMAGE_URL='https://download.fedoraproject.org/pub/fedora/linux/releases/30/Container/x86_64/images/Fedora-Container-Base-30-1.2.x86_64.tar.xz'
   
 }
 
@@ -1036,12 +1036,16 @@ do_install()
     eval_crit mount -o bind /dev/pts ${CHRX_INSTALL_ROOT}/fedora/dev/pts
     eval_crit mount -o bind /sys     ${CHRX_INSTALL_ROOT}/fedora/sys
     eval_crit mount -o bind /run     ${CHRX_INSTALL_ROOT}/fedora/run
-
     eval_crit mount -o bind ${CHRX_INSTALL_ROOT}     ${CHRX_INSTALL_ROOT}/fedora/mnt
     
+    LC_OLD=${LC_ALL}
+    export LC_ALL=
+    
     echo_info "\nInstalling Fedora core packages..."
-    chroot ${CHRX_INSTALL_ROOT}/fedora /bin/bash -c "dnf ${VERBOSITY_DNF} -y --nogpgcheck --releasever=${CHRX_OS_VERSION} --installroot=/mnt/ group install core"
+    chroot ${CHRX_INSTALL_ROOT}/fedora /bin/bash -c "dnf ${VERBOSITY_DNF} -y --nogpgcheck --releasever=${CHRX_OS_VERSION} --setopt='module_platform_id=platform:f${CHRX_OS_VERSION}' --installroot=/mnt/ group install core"
 
+    export LC_ALL=${LC_OLD}
+    
     umount ${CHRX_INSTALL_ROOT}/fedora/mnt
     umount ${CHRX_INSTALL_ROOT}/fedora/proc
     umount ${CHRX_INSTALL_ROOT}/fedora/dev/pts
@@ -1080,7 +1084,7 @@ do_install()
   mkdir -p ${CHRX_INSTALL_ROOT}${CHRX_CACHE_DIR}
   cd ${CHRX_INSTALL_ROOT}${CHRX_CACHE_DIR}
   curl ${VERBOSITY_CURL} ${CHRX_WEB_ROOT}/dist.tar.gz | tar xz --no-same-owner
-  
+
   if [ "${CHRX_CUSTOMIZATION_ENABLED}" ]; then
     install_customizations
   else

--- a/dist/chrx-install-chroot
+++ b/dist/chrx-install-chroot
@@ -298,7 +298,7 @@ fedora_install_distenv()
     ;;
   esac
   echo_title "Installing \"${CHRX_OS_DISTENV}\"."
-  dnf ${VERBOSITY_DNF} -y group install "${CHRX_OS_DISTENV}"
+  dnf ${VERBOSITY_DNF} -y --allowerasing group install "${CHRX_OS_DISTENV}"
 }
 
 chrome_add_repos()
@@ -510,7 +510,11 @@ fedora_install_kernel()
 {
   echo "add_drivers+=\" mmc_core mmc_block sdhci sdhci_acpi \"" > /etc/dracut.conf.d/chrx.conf
   echo_title "Installing Linux kernel and boot environment."
-  
+
+  # Remove anything installed outside the chroot in case the main install
+  # has included these accidentally
+  dnf ${VERBOSITY_DNF} -y remove kernel kernel-modules kernel-core linux-firmware
+
   # install the release kernel
   dnf ${VERBOSITY_DNF} -y --disablerepo "updates" install kernel kernel-modules kernel-core linux-firmware
   #and then update to the latest


### PR DESCRIPTION
HI,

This should fix some errors seen from about a month after the release of Fedora 30.

This has now been tested to work with the release of both 30 and 31

The main issue was the removal of the older 27 cloud image.

There are also some extra options that needed to change when using the 30 cloud image, around setting the default modules to the correct release version.