### PR TITLE
Readding updated advanced usage block for local development or mirroring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *~
 *.swp
 util/
+dist.tar.gz

--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ you can quote the argument, e.g.: `-p "gimp blender inkscape"`.
 `chrx -d ubuntu -e standard -r 16.04 -H hal -U dave -p admin-misc`
 
 
-<!--
 <a name="advanced-usage"></a>
 ### advanced usage
 
@@ -151,14 +150,23 @@ There are many good reasons to do so, especially if you'll be doing
 a large number of installations. However, setup can be somewhat more
 complicated, and instructions are outside the scope of this README.
 
-To point **chrx** at your cache, just set the `CHRX_WEB_ROOT`
-environment variable before running the `chrx` script, like this:
+To point **chrx** at a local copy, just set the `CHRX_WEB_ROOT`
+environment variable after running `bash make-dist.sh` script, like this:
 
 ```
-export CHRX_WEB_ROOT="http://myserver/chrx"
-cd ; curl -O $CHRX_WEB_ROOT/go && sh go
+# Auto version dev appended
+bash make-dist.sh
+# Explicit version no dev appended
+CHRX_VERSION=3.3.3 bash make-dist.sh
+# manual fetch of local version
+export CHRX_WEB_ROOT="http://localhost:8000/"
+curl http://$CHRX_WEB_ROOT/dist.tar.gz | sudo tar xzfC - /usr/local && chrx -h
+# or just source the convenience script that exports the variable and
+# installs chrx, most useful if you already partitioned your disk and
+# are adding a new distro or adding more testing to the installer
+. fetch-install-from-local.sh
+chrx -h | grep -E 'installer.*version'
 ```
--->
 
 <a name="compatibility"></a>
 ## compatibility

--- a/fetch-install-from-local.sh
+++ b/fetch-install-from-local.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+cleanup() { pkill python3; }
+# Don't want previous `pkill -P $$` which would kill parent session if sourced?
+# trap cleanup EXIT
+export CHRX_WEB_ROOT="http://localhost:8000/"
+python3 -m http.server &
+sleep 3 # Lets the webserver start
+curl $CHRX_WEB_ROOT/dist.tar.gz | sudo tar xzfC - /usr/local 
+# Only necessary if tar doesn't preserve permissions
+# && sudo chmod +x /usr/local/bin/chrx*
+chrx -h
+chrx -h | grep -E 'installer.*version'
+cleanup

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# If you specify a version it will get packed into the chrx-install otherwise we append a string to denote it isn't a release build
+# NEED_TEST
+# pseudo TEST chrx -h | grep -E 'installer.*version'
+: ${CHRX_VERSION:=$(grep -E '^CHRX_VERSION=' ./chrx-install | cut -f 2 -d '='| sed -e 's/"//g')-dev}
+chrx_src=$(pwd)
+build_dir=$(mktemp -d -t chrx.XXX)
+cleanup() { rm -rf $build_dir; }
+trap cleanup EXIT
+echo $build_dir
+cd $build_dir
+mkdir bin
+cp $chrx_src/chrx* ./bin
+cp $chrx_src/dist/chrx* ./bin
+# NEED_TEST
+# Tweak the CHRX_VERSION in chrx-install
+sed -i -e '/CHRX_VERSION=/ s/CHRX_VERSION=.*/CHRX_VERSION='$CHRX_VERSION'/' ./bin/chrx-install
+# Debug print updated version
+grep -E '^CHRX_VERSION=' ./bin/chrx-install
+# Make sure they are executable as tar should preserve this on extract
+chmod -R +x ./bin
+mkdir -p etc/chrx-files
+mv ./bin/chrx-devices ./etc/
+rm -rf $chrx_src/dist/etc/etc/
+cp -r -t ./etc/chrx-files/ $chrx_src/dist/etc/
+cd $chrx_src
+# NEED_TEST
+tar czf dist.tar.gz -C $build_dir $(ls -A $build_dir)
+# Debug print contents for comparison to official chrx.org version
+echo "Confirm contents"
+tar tf dist.tar.gz


### PR DESCRIPTION
I've been working with a Whiskey Lake system that has the AltFW implementation that allows installing Tianocore in the RW_LEGACY slot which allows booting Linux distributions from USB or theoretically the local disk via Tianocore but the chrx installed GalliumOS appears to be using legacy grub-pc even though I tweaked the install script to add grub-efi. I may need to change the package getting installed to the grub-amd64-signed and shim, but that is a separate concern.

While working through this process I reverse-engineered a way to "host" and install chrx full in Crosh using only tools available on the local system to the local system, but in a manner that could also be pushed to a trusted server or packaged as a Docker container. I may add some more details in the future around the Docker option the currently it is working really well to build a dist.tar.gz and fetch it and install the updated scripts in a similar manner to how the chrx.org instructions work.