### PR TITLE
On some systems 400 is way too dim

### DIFF
--- a/dist/etc/rc.local
+++ b/dist/etc/rc.local
@@ -36,7 +36,8 @@ echo EHCI > /proc/acpi/wakeup
 echo XHCI > /proc/acpi/wakeup
 
 ## set backlight brightness on boot (min is 0, max is 937)
-echo 400 > /sys/class/backlight/intel_backlight/brightness
+max_bright=$(cat /sys/class/backlight/intel_backlight/max_brightness)
+echo $(( max_bright / 4 ))  > /sys/class/backlight/intel_backlight/brightness
 
 exit 0
 ## end chrx additions


### PR DESCRIPTION
Calculate 25% brightness based on max_brightness. Could change to `/ 2` for 50% brightness.